### PR TITLE
feat(mail): add native Mail Server and Webmail module

### DIFF
--- a/mail-stack/README.md
+++ b/mail-stack/README.md
@@ -1,0 +1,72 @@
+# QuickBox Pro - Mail Stack
+
+This module provides a native Mail Server and Webmail client using a containerized approach.
+
+## Components
+- **Backend**: [docker-mailserver](https://github.com/docker-mailserver/docker-mailserver) (Postfix, Dovecot, SpamAssassin, ClamAV, Fail2Ban).
+- **Webmail**: [SnappyMail](https://github.com/the-djmaze/snappymail) - A fast, modern, and database-less webmail client.
+
+## Requirements
+- Docker and Docker Compose (v2+)
+- A valid SSL certificate (e.g., from Let's Encrypt)
+- Open ports: 25, 143, 465, 587, 993, and 8888 (for webmail)
+
+## Installation
+1. Navigate to the `mail-stack` directory.
+2. Run the deployment script:
+   ```bash
+   sudo ./deploy.sh
+   ```
+3. Follow the prompts to configure your domain, SSL paths, and optional relay host.
+
+## Management
+Use the `manage-mail.sh` script to manage your mailboxes:
+- **Add/Update mailbox**: `./manage-mail.sh add user@domain.com password`
+- **Remove mailbox**: `./manage-mail.sh del user@domain.com`
+- **List mailboxes**: `./manage-mail.sh list`
+- **View DKIM records**: `./manage-mail.sh dkim`
+
+## DNS Configuration
+After installation, you **MUST** configure your DNS records for mail to function correctly and avoid being marked as spam:
+
+| Record Type | Name | Value | Purpose |
+| :--- | :--- | :--- | :--- |
+| **MX** | `@` | `mail.yourdomain.com` | Directs incoming mail to your server |
+| **A** | `mail` | `YOUR_SERVER_IP` | Points mail hostname to your server |
+| **SPF** | `@` | `v=spf1 mx ~all` | Authorizes your server to send mail |
+| **DKIM** | `mail._domainkey` | (Output from `./manage-mail.sh dkim`) | Cryptographically signs outgoing mail |
+| **DMARC** | `_dmarc` | `v=DMARC1; p=none; rua=mailto:admin@yourdomain.com` | Instructs receivers on how to handle failed SPF/DKIM |
+
+## SnappyMail Webmail Configuration
+1. Access the SnappyMail admin panel at `https://mail.yourdomain.com/?admin` (or `http://YOUR_IP:8888/?admin`).
+2. The default login is **admin** with **no password**. You will be prompted to set an admin password on your first visit.
+3. In the admin panel, go to **Domains** and ensure your domain is configured to use the `mailserver` container:
+   - **IMAP**: `mailserver` (Port 143, STARTTLS)
+   - **SMTP**: `mailserver` (Port 587, STARTTLS)
+
+## SSL Integration & Renewal
+The mail server maps the certificates you specify during installation. If you are using Let's Encrypt (standard in QuickBox), the certificates will be automatically mapped.
+To pick up renewed certificates, you can use the provided reload script:
+```bash
+sudo ./reload-certs.sh
+```
+It is recommended to add this script as a post-renewal hook for Certbot or as a weekly cron job.
+
+## Troubleshooting
+### Port 25 is Blocked
+Many VPS providers (Hetzner, DigitalOcean, Vultr, etc.) block outbound Port 25 by default.
+- **Symptom**: You can receive mail but cannot send it.
+- **Solution**: Use an SMTP Relay (like SendGrid, Mailgun, or Amazon SES). The `deploy.sh` script includes an option to configure this automatically.
+
+### Port Conflicts
+If the installer fails due to port conflicts, ensure you don't have a default `postfix` or `exim4` service running on the host:
+```bash
+sudo systemctl stop postfix
+sudo systemctl disable postfix
+```
+
+### Resource Usage
+ClamAV (Antivirus) is disabled by default to save RAM. If you have 4GB+ of RAM and wish to enable it, set `ENABLE_CLAMAV=1` in `mailserver.env` and restart the stack:
+```bash
+docker compose up -d
+```

--- a/mail-stack/deploy.sh
+++ b/mail-stack/deploy.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# QuickBox Pro - Mail Stack Deployment Script
+# Shellcheck disable=SC2086
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}QuickBox Pro - Mail Stack Installer${NC}"
+echo "======================================"
+
+# Pre-flight checks
+echo -n "Checking for Docker... "
+if ! command -v docker &>/dev/null; then
+    echo -e "${RED}FAILED${NC}"
+    echo "Please install Docker before proceeding."
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}"
+
+echo -n "Checking for Docker Compose... "
+if ! docker compose version &>/dev/null; then
+    echo -e "${RED}FAILED${NC}"
+    echo "Please install Docker Compose (v2+) before proceeding."
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}"
+
+echo -n "Checking outbound Port 25... "
+if ! timeout 2 bash -c "</dev/tcp/google.com/25" &>/dev/null; then
+    echo -e "${YELLOW}BLOCKED${NC}"
+    echo -e "${YELLOW}WARNING: Outbound Port 25 is blocked. You WILL need a Relay Host to send emails.${NC}"
+else
+    echo -e "${GREEN}OPEN${NC}"
+fi
+
+# Check for port conflicts
+REQUIRED_PORTS=(25 143 465 587 993 8888)
+CONFLICTS=()
+for port in "${REQUIRED_PORTS[@]}"; do
+    if ss -tln | grep -q ":${port} "; then
+        CONFLICTS+=("${port}")
+    fi
+done
+
+if [[ ${#CONFLICTS[@]} -gt 0 ]]; then
+    echo -e "${RED}PORT CONFLICTS DETECTED:${NC}"
+    for port in "${CONFLICTS[@]}"; do
+        echo -e " - Port ${port} is already in use."
+    done
+    echo "Please stop any services (like a default Postfix) using these ports before installing."
+    exit 1
+fi
+
+# Configuration
+if [[ ! -f "mailserver.env" ]]; then
+    if [[ -f "mailserver.env.template" ]]; then
+        cp mailserver.env.template mailserver.env
+    else
+        touch mailserver.env
+    fi
+fi
+ln -sf mailserver.env .env
+
+# Interactive Prompt
+while true; do
+    read -rp "Enter your Mail Domain (e.g. example.com): " MAIL_DOMAIN
+    [[ -n "${MAIL_DOMAIN}" ]] && break
+    echo -e "${RED}Domain cannot be empty!${NC}"
+done
+
+while true; do
+    read -rp "Enter your Mail Hostname [mail.${MAIL_DOMAIN}]: " MAIL_HOSTNAME
+    MAIL_HOSTNAME=${MAIL_HOSTNAME:-mail.${MAIL_DOMAIN}}
+    [[ -n "${MAIL_HOSTNAME}" ]] && break
+done
+
+# Default SSL Paths for QuickBox
+DEFAULT_CERT="/etc/nginx/ssl/quickbox.crt"
+DEFAULT_KEY="/etc/nginx/ssl/quickbox.key"
+
+while true; do
+    read -rp "Enter path to SSL Certificate (fullchain) [${DEFAULT_CERT}]: " SSL_CERT_PATH
+    SSL_CERT_PATH=${SSL_CERT_PATH:-${DEFAULT_CERT}}
+    if [[ -f "${SSL_CERT_PATH}" ]]; then break; else echo -e "${RED}File not found!${NC}"; fi
+done
+
+while true; do
+    read -rp "Enter path to SSL Private Key [${DEFAULT_KEY}]: " SSL_KEY_PATH
+    SSL_KEY_PATH=${SSL_KEY_PATH:-${DEFAULT_KEY}}
+    if [[ -f "${SSL_KEY_PATH}" ]]; then break; else echo -e "${RED}File not found!${NC}"; fi
+done
+
+# Update .env robustly
+update_env() {
+    local key=$1
+    local value=$2
+    # Escape value for sed
+    local escaped_value=$(echo "${value}" | sed 's/[&/\]/\\&/g')
+    if grep -q "^${key}=" mailserver.env; then
+        sed -i "s|^${key}=.*|${key}=${escaped_value}|" mailserver.env
+    else
+        echo "${key}=${escaped_value}" >> mailserver.env
+    fi
+}
+
+update_env "MAIL_DOMAIN" "${MAIL_DOMAIN}"
+update_env "MAIL_HOSTNAME" "${MAIL_HOSTNAME}"
+update_env "SSL_CERT_PATH" "${SSL_CERT_PATH}"
+update_env "SSL_KEY_PATH" "${SSL_KEY_PATH}"
+
+# Relay Configuration
+read -rp "Do you want to configure a Relay Host? (y/n): " CONFIGURE_RELAY
+if [[ "${CONFIGURE_RELAY,,}" == "y" ]]; then
+    read -rp "Relay Host: " RELAY_HOST
+    read -rp "Relay Port [587]: " RELAY_PORT
+    RELAY_PORT=${RELAY_PORT:-587}
+    read -rp "Relay User: " RELAY_USER
+    read -rp "Relay Password: " RELAY_PASSWORD
+
+    update_env "RELAY_HOST" "${RELAY_HOST}"
+    update_env "RELAY_PORT" "${RELAY_PORT}"
+    update_env "RELAY_USER" "${RELAY_USER}"
+    update_env "RELAY_PASSWORD" "${RELAY_PASSWORD}"
+fi
+
+# Create directories
+mkdir -p config/mail-data config/mail-state config/mail-config config/snappymail-data
+
+# Pull and Start
+echo "Starting containers..."
+docker compose pull
+docker compose up -d
+
+# DKIM Generation
+echo "Generating DKIM keys..."
+docker exec mailserver setup config dkim domain "${MAIL_DOMAIN}"
+
+echo "======================================"
+echo -e "${GREEN}Mail Stack successfully deployed!${NC}"
+echo -e "Webmail: ${YELLOW}https://${MAIL_HOSTNAME}${NC} (once Nginx is configured)"
+echo -e "Management: Use ${YELLOW}./manage-mail.sh${NC} to add mailboxes."
+echo ""
+echo "IMPORTANT: Configure your DNS records (MX, SPF, DKIM, DMARC)."
+echo "View DKIM public key with: ./manage-mail.sh dkim"

--- a/mail-stack/docker-compose.yml
+++ b/mail-stack/docker-compose.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  mailserver:
+    image: mailserver/docker-mailserver:14
+    container_name: mailserver
+    hostname: ${MAIL_HOSTNAME}
+    domainname: ${MAIL_DOMAIN}
+    ports:
+      - "25:25"
+      - "143:143"
+      - "465:465"
+      - "587:587"
+      - "993:993"
+    volumes:
+      - ./config/mail-data/:/var/mail/
+      - ./config/mail-state/:/var/mail-state/
+      - ./config/mail-config/:/tmp/docker-mailserver/
+      - /etc/localtime:/etc/localtime:ro
+      - ${SSL_CERT_PATH}:/etc/letsencrypt/live/${MAIL_DOMAIN}/fullchain.pem:ro
+      - ${SSL_KEY_PATH}:/etc/letsencrypt/live/${MAIL_DOMAIN}/privkey.pem:ro
+    environment:
+      - MAIL_DOMAIN=${MAIL_DOMAIN}
+      - MAIL_HOSTNAME=${MAIL_HOSTNAME}
+      - ENABLE_SPAMASSASSIN=${ENABLE_SPAMASSASSIN:-1}
+      - ENABLE_CLAMAV=${ENABLE_CLAMAV:-0}
+      - ENABLE_FAIL2BAN=${ENABLE_FAIL2BAN:-1}
+      - ONE_DIR=${ONE_DIR:-1}
+      - DMS_DEBUG=${DMS_DEBUG:-0}
+      - SSL_TYPE=manual
+      - SSL_CERT_PATH=/etc/letsencrypt/live/${MAIL_DOMAIN}/fullchain.pem
+      - SSL_KEY_PATH=/etc/letsencrypt/live/${MAIL_DOMAIN}/privkey.pem
+      - RELAY_HOST=${RELAY_HOST}
+      - RELAY_PORT=${RELAY_PORT:-587}
+      - RELAY_USER=${RELAY_USER}
+      - RELAY_PASSWORD=${RELAY_PASSWORD}
+    cap_add:
+      - NET_ADMIN
+      - SYS_PTRACE
+    restart: always
+    networks:
+      - mail_network
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 2G
+
+  webmail:
+    image: snappymail/snappymail:latest
+    container_name: snappymail
+    ports:
+      - "8888:80"
+    volumes:
+      - ./config/snappymail-data/:/var/www/snappymail/data/
+    restart: always
+    networks:
+      - mail_network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
+networks:
+  mail_network:
+    name: mail_network
+    driver: bridge

--- a/mail-stack/mailserver.env
+++ b/mail-stack/mailserver.env
@@ -1,0 +1,21 @@
+# General Configuration
+MAIL_DOMAIN=example.com
+MAIL_HOSTNAME=mail.example.com
+
+# SSL Configuration
+SSL_CERT_PATH=/etc/nginx/ssl/quickbox.crt
+SSL_KEY_PATH=/etc/nginx/ssl/quickbox.key
+
+# Relay Host Configuration
+RELAY_HOST=
+RELAY_PORT=587
+RELAY_USER=
+RELAY_PASSWORD=
+
+# Docker Mailserver Feature Toggles
+# ClamAV is RAM-intensive, disabled by default.
+ENABLE_SPAMASSASSIN=1
+ENABLE_CLAMAV=0
+ENABLE_FAIL2BAN=1
+ONE_DIR=1
+DMS_DEBUG=0

--- a/mail-stack/mailserver.env.template
+++ b/mail-stack/mailserver.env.template
@@ -1,0 +1,20 @@
+# General Configuration
+MAIL_DOMAIN=
+MAIL_HOSTNAME=
+
+# SSL Configuration
+SSL_CERT_PATH=/etc/nginx/ssl/quickbox.crt
+SSL_KEY_PATH=/etc/nginx/ssl/quickbox.key
+
+# Relay Host Configuration
+RELAY_HOST=
+RELAY_PORT=587
+RELAY_USER=
+RELAY_PASSWORD=
+
+# Docker Mailserver Feature Toggles
+ENABLE_SPAMASSASSIN=1
+ENABLE_CLAMAV=0
+ENABLE_FAIL2BAN=1
+ONE_DIR=1
+DMS_DEBUG=0

--- a/mail-stack/manage-mail.sh
+++ b/mail-stack/manage-mail.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# QuickBox Pro - Mail Stack Management Script
+
+set -euo pipefail
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+function usage() {
+    echo "Usage: $0 [command]"
+    echo ""
+    echo "Commands:"
+    echo "  add [email] [password]  Add a new mailbox (or update password)"
+    echo "  del [email]             Remove a mailbox"
+    echo "  list                    List all mailboxes"
+    echo "  passwd [email] [pass]   Change mailbox password"
+    echo "  dkim                    View DKIM keys for DNS setup"
+    echo "  help                    Show this help"
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+COMMAND=$1
+shift
+
+# Check if terminal is interactive
+DOCKER_OPTS="-i"
+[[ -t 0 ]] && DOCKER_OPTS="-it"
+
+case "${COMMAND}" in
+    add|passwd)
+        if [[ $# -lt 2 ]]; then
+            echo "Usage: $0 ${COMMAND} [email] [password]"
+            exit 1
+        fi
+        docker exec ${DOCKER_OPTS} mailserver setup email add "$1" "$2"
+        ;;
+    del)
+        if [[ $# -lt 1 ]]; then
+            echo "Usage: $0 del [email]"
+            exit 1
+        fi
+        docker exec ${DOCKER_OPTS} mailserver setup email del "$1"
+        ;;
+    list)
+        docker exec ${DOCKER_OPTS} mailserver setup email list
+        ;;
+    dkim)
+        DOMAIN=$(docker exec mailserver bash -c 'echo ${MAIL_DOMAIN:-}')
+        if [[ -z "${DOMAIN}" ]]; then
+            DOMAIN=$(docker exec mailserver ls /tmp/docker-mailserver/opendkim/keys/ 2>/dev/null | head -n 1)
+        fi
+
+        if [[ -n "${DOMAIN}" ]]; then
+            KEY_FILE="/tmp/docker-mailserver/opendkim/keys/${DOMAIN}/mail.txt"
+            if docker exec mailserver test -f "${KEY_FILE}"; then
+                echo -e "${GREEN}DKIM Public Key for ${DOMAIN}:${NC}"
+                docker exec mailserver cat "${KEY_FILE}"
+            else
+                echo -e "${RED}DKIM key file not found at ${KEY_FILE}${NC}"
+            fi
+        else
+            echo -e "${RED}Could not determine MAIL_DOMAIN.${NC}"
+        fi
+        ;;
+    help|*)
+        usage
+        ;;
+esac

--- a/mail-stack/nginx-snappymail.conf.template
+++ b/mail-stack/nginx-snappymail.conf.template
@@ -1,0 +1,40 @@
+# Nginx Configuration Template for SnappyMail Webmail
+# Replace ${MAIL_HOSTNAME}, ${SSL_CERT_PATH}, and ${SSL_KEY_PATH} with actual values.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${MAIL_HOSTNAME};
+
+    # Redirect to HTTPS
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${MAIL_HOSTNAME};
+
+    ssl_certificate ${SSL_CERT_PATH};
+    ssl_certificate_key ${SSL_KEY_PATH};
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
+    add_header X-XSS-Protection "1; mode=block";
+
+    location / {
+        proxy_pass http://127.0.0.1:8888;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Max upload size for attachments
+        client_max_body_size 50M;
+    }
+
+    # Optional: Disable logging for favicon and robots.txt
+    location = /favicon.ico { log_not_found off; access_log off; }
+    location = /robots.txt  { log_not_found off; access_log off; }
+}

--- a/mail-stack/reload-certs.sh
+++ b/mail-stack/reload-certs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# QuickBox Pro - Mail Stack Certificate Reload Script
+# This script restarts the mailserver container to pick up renewed SSL certificates.
+# You can add this to your crontab or use it as a post-renewal hook for Certbot/acme.sh.
+
+set -euo pipefail
+
+# Navigate to the script directory to ensure docker compose works if needed
+cd "$(dirname "$0")"
+
+if command -v docker &>/dev/null && docker ps --format '{{.Names}}' | grep -q "^mailserver$"; then
+    echo "Reloading mailserver certificates..."
+    docker restart mailserver
+    echo "Mailserver certificates reloaded successfully."
+else
+    echo "Mailserver container is not running. No reload needed."
+fi


### PR DESCRIPTION
- Added `mail-stack/` directory with `docker-mailserver` (pinned to v14) and `SnappyMail`.
- Implemented `deploy.sh` with pre-flight checks (port conflicts, outbound Port 25) and interactive config.
- Added `manage-mail.sh` for mailbox administration (add, del, list, passwd) and DKIM retrieval.
- Integrated `reload-certs.sh` for automated SSL propagation.
- Provided thorough documentation in `README.md` covering DNS, Webmail setup, and troubleshooting.
- Included Nginx reverse proxy template for webmail client.
- Added explicit CPU/Memory limits for all mail stack services.